### PR TITLE
feat: add tmux-notify plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -29,6 +29,29 @@
         "rules",
         "path-specific"
       ]
+    },
+    {
+      "name": "tmux-notify",
+      "description": "tmux notifications for Claude Code — bell, display-message, and auto-focus",
+      "version": "1.0.0",
+      "author": {
+        "name": "claude-contrib"
+      },
+      "source": "./plugins/tmux-notify",
+      "category": "automation",
+      "tags": [
+        "tmux",
+        "notification",
+        "bell"
+      ],
+      "keywords": [
+        "tmux",
+        "notification",
+        "bell",
+        "focus",
+        "background",
+        "pane"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Extensions are **passive plugins** — they don't require invocation:
 
 | Type | Trigger | Example |
 |------|---------|---------|
-| **Hooks** | Claude Code events (`SessionStart`, `PreToolUse`, `PostToolUse`) | Sync rules on startup, lint after edits |
+| **Hooks** | Claude Code events (`SessionStart`, `Stop`, `Notification`, …) | Sync rules on startup, notify on completion |
 | **Context rules** | Path patterns | Inject team conventions scoped to `src/api/**` |
 
 Install once. Works on every future session automatically.
@@ -49,6 +49,7 @@ That's it — the extension activates on your next session start.
 | Extension | Description |
 |-----------|-------------|
 | [`agents-context`](plugins/agents-context/README.md) | Automatically syncs [AGENTS.md](https://agents.md/) files into Claude Code path-specific rules on every session start |
+| [`tmux-notify`](plugins/tmux-notify/README.md) | tmux notifications for Claude Code — bell, display-message, and auto-focus |
 
 ## Publish Your Own Extension
 

--- a/plugins/tmux-notify/.claude-plugin/plugin.json
+++ b/plugins/tmux-notify/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "tmux-notify",
+  "version": "1.0.0",
+  "description": "tmux notifications for Claude Code — bell, display-message, and auto-focus",
+  "author": {
+    "name": "claude-contrib",
+    "email": "claude-contrib@github.com",
+    "url": "https://github.com/claude-contrib"
+  },
+  "homepage": "https://github.com/claude-contrib/claude-extensions",
+  "repository": "https://github.com/claude-contrib/claude-extensions",
+  "license": "MIT",
+  "keywords": ["tmux", "notification", "bell", "focus", "background"]
+}

--- a/plugins/tmux-notify/README.md
+++ b/plugins/tmux-notify/README.md
@@ -1,0 +1,83 @@
+# tmux-notify
+
+> Get notified in tmux when Claude Code finishes a task or needs your attention — per-pane, with no status bar conflicts.
+
+## What it does
+
+When you run Claude Code in a background tmux pane, you need a reliable signal when it's done. Status bar widgets break when you have multiple Claude instances because they share state across windows. `tmux-notify` works at the pane level using three independent mechanisms:
+
+- **Bell** — writes `\a` directly to the pane's TTY so your terminal flashes/beeps regardless of which window is active
+- **Display-message** — shows a contextual message in the tmux status area when Claude's window is out of focus
+- **Auto-focus** — selects Claude's pane within its window when Claude completes or needs attention
+
+Bell is on by default; the other two are opt-in. All three work independently.
+
+## Installation
+
+```
+/plugin install tmux-notify@claude-extensions
+```
+
+## Configuration
+
+Set options in `~/.tmux.conf` for persistence, or at runtime with `tmux set-option`:
+
+| Option | Default | Values | Description |
+|--------|---------|--------|-------------|
+| `@claude-notify-bell` | `on` | `on` / `off` | Write `\a` to the pane TTY (visual/audible bell) |
+| `@claude-notify-message` | `off` | `on` / `off` | Show contextual message when Claude's window is inactive |
+| `@claude-notify-auto-focus` | `off` | `on` / `off` | Select Claude's pane within its window |
+
+**`~/.tmux.conf` example:**
+
+```
+set-option -g @claude-notify-bell on
+set-option -g @claude-notify-message on
+set-option -g @claude-notify-auto-focus off
+```
+
+**Runtime (takes effect immediately):**
+
+```bash
+tmux set-option -g @claude-notify-message on
+tmux set-option -g @claude-notify-auto-focus off
+```
+
+## How it works
+
+The plugin hooks into two Claude Code events — `Stop` (Claude finishes responding) and `Notification` (Claude needs attention, e.g. a permission prompt) — and runs `tmux_notify.sh` in the context of the pane where Claude is running.
+
+### Bell
+
+Writes the ASCII bell character (`\a`) directly to `#{pane_tty}` — the TTY device of the pane where Claude is running. This triggers the terminal's bell action (visual flash, audible beep, or dock badge depending on your terminal settings) independently of which pane is currently focused.
+
+### Display-message
+
+Compares Claude's `#{window_id}` to the currently active window within the same tmux session. If they differ (i.e. you've switched away from Claude's window), it runs `tmux display-message` with a short, fixed message:
+
+| Event | Message shown |
+|-------|--------------|
+| `Stop` | `Claude [window]: done` |
+| `Notification` | `Claude [window]: waiting` |
+
+Where `window` is the tmux window name of Claude's pane.
+
+### Auto-focus
+
+Selects Claude's pane within its window via `tmux select-pane -t $TMUX_PANE`. Fires on both Stop and Notification events. Uses a short delay (0.5s) to run after Claude Code finishes its terminal UI update. Only affects the current window — it does not switch windows.
+
+## Active pane detection
+
+The script compares `#{pane_id}` of the active pane to `$TMUX_PANE` (the pane where Claude is running). If they match — meaning Claude's pane is already focused — all notifications and auto-focus are skipped. This prevents bells and popups when you're already looking at Claude.
+
+## Multiple Claude instances
+
+Each pane that runs Claude has its own `$TMUX_PANE` environment variable set by tmux. The notification script uses `$TMUX_PANE` to target only its own pane, so two Claude instances running in separate panes each send their bell to their own TTY independently. No coordination needed.
+
+## Contributing
+
+Issues and pull requests welcome at [claude-contrib/claude-extensions](https://github.com/claude-contrib/claude-extensions).
+
+## License
+
+MIT

--- a/plugins/tmux-notify/hooks/hooks.json
+++ b/plugins/tmux-notify/hooks/hooks.json
@@ -1,0 +1,29 @@
+{
+  "description": "Notify via tmux bell, display-message, or auto-focus when Claude completes or needs attention",
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/tmux_notify.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/tmux_notify.sh",
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/tmux-notify/scripts/tmux_notify.sh
+++ b/plugins/tmux-notify/scripts/tmux_notify.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+#
+# tmux_notify.sh - tmux notification hook for Claude Code
+#
+# DESCRIPTION:
+#   Sends notifications to the tmux pane running Claude Code when it completes
+#   a task or needs attention. Supports three mechanisms: visual bell,
+#   display-message, and auto-focus — all configurable via tmux session options.
+#
+# USAGE:
+#   Invoked automatically by Claude Code hooks on Stop and Notification events.
+#
+# TMUX OPTIONS (set via tmux set-option -g <option> <value>):
+#   @claude-notify-bell        on  - Write \a to the pane TTY (visual bell)
+#   @claude-notify-message     off - Show display-message when Claude's window is inactive
+#   @claude-notify-auto-focus  off - Switch focus to Claude's pane on completion
+#
+# STDIN (JSON from Claude Code):
+#   hook_event_name        - "Stop" or "Notification"
+#
+# EXIT CODES:
+#   0 - Success (including graceful no-op when not in tmux)
+#   Non-zero - tmux command error
+
+set -euo pipefail
+
+# Read tmux option with fallback default
+#
+# Args:
+#   $1 - Option name
+#   $2 - Default value if option is not set
+#
+# Returns:
+#   Prints the option value or default
+_tmux_option() {
+  local option="$1"
+  local default="$2"
+  local value
+  value="$(tmux show-option -gv "$option" 2>/dev/null || true)"
+  if [[ -z "$value" ]]; then
+    echo "$default"
+  else
+    echo "$value"
+  fi
+}
+
+# Extract a string field from the JSON event_args
+#
+# Uses jq when available, falls back to sed for environments without it.
+#
+# Args:
+#   $1 - Field name
+#   $2 - JSON event_args string
+#
+# Returns:
+#   Prints the field value, or empty string if not present
+_json_field() {
+  local field="$1"
+  local json="$2"
+  if command -v jq &>/dev/null; then
+    printf '%s' "$json" | jq -r --arg f "$field" '.[$f] // empty'
+  else
+    printf '%s' "$json" | sed -n "s/.*\"${field}\"[[:space:]]*:[[:space:]]*\"\([^\"]*\)\".*/\1/p" | head -1
+  fi
+}
+
+# Prints the current tmux session ID
+_tmux_current_session() {
+  tmux display-message -p "#{session_id}"
+}
+
+# Prints the currently active tmux window ID
+_tmux_active_window() {
+  tmux display-message -p "#{window_id}"
+}
+
+# Prints the currently active tmux pane ID
+_tmux_active_pane() {
+  tmux display-message -p "#{pane_id}"
+}
+
+# Prints the TTY device path of Claude's pane
+_tmux_pane_tty() {
+  tmux display-message -p -t "${TMUX_PANE}" "#{pane_tty}"
+}
+
+# Prints the session ID of Claude's pane
+_tmux_pane_session() {
+  tmux display-message -p -t "${TMUX_PANE}" "#{session_id}"
+}
+
+# Prints the window ID of Claude's pane
+_tmux_pane_window() {
+  tmux display-message -p -t "${TMUX_PANE}" "#{window_id}"
+}
+
+# Prints the window name of Claude's pane
+_tmux_pane_window_name() {
+  tmux display-message -p -t "${TMUX_PANE}" "#{window_name}"
+}
+
+# Returns 0 if @claude-notify-bell is enabled
+_tmux_bell_enabled() {
+  [[ "$(_tmux_option "@claude-notify-bell" "on")" == "on" ]]
+}
+
+# Returns 0 if @claude-notify-message is enabled
+_tmux_display_message_enabled() {
+  [[ "$(_tmux_option "@claude-notify-message" "off")" == "on" ]]
+}
+
+# Returns 0 if @claude-notify-auto-focus is enabled
+_tmux_auto_focus_enabled() {
+  [[ "$(_tmux_option "@claude-notify-auto-focus" "off")" == "on" ]]
+}
+
+# Returns 0 if Claude's pane is the currently active pane
+_is_active_pane() {
+  [[ "$(_tmux_active_pane)" == "${TMUX_PANE:-}" ]]
+}
+
+# Send bell and display-message notifications
+#
+# Applies the bell and display-message mechanisms according to the configured
+# tmux options. Skipped entirely when Claude's pane is already active.
+#
+# Args:
+#   $1 - Message text to show in display-message
+_notify() {
+  local text="$1"
+
+  if _is_active_pane; then
+    return 0
+  fi
+
+  # Bell: write \a to the pane's TTY
+  if _tmux_bell_enabled; then
+    printf '\a' >"$(_tmux_pane_tty)" || true
+  fi
+
+  # Display-message: show message only when in the same session and Claude's window is not active
+  if _tmux_display_message_enabled; then
+    if [[ "$(_tmux_current_session)" == "$(_tmux_pane_session)" ]]; then
+      local active_window
+      active_window="$(_tmux_active_window)"
+
+      local claude_window
+      claude_window="$(_tmux_pane_window)"
+
+      if [[ "$active_window" != "$claude_window" ]]; then
+        tmux display-message -l "$text"
+      fi
+    fi
+  fi
+}
+
+# Switch focus to Claude's pane
+#
+# Selects Claude's pane within the current window. Only acts when
+# @claude-notify-auto-focus is on and the pane is not already active.
+# Uses a short delay to run after Claude Code finishes its UI update.
+_auto_focus() {
+  if _is_active_pane; then
+    return 0
+  fi
+
+  if _tmux_auto_focus_enabled; then
+    (sleep 0.5 && tmux select-pane -t "${TMUX_PANE}") &
+    disown
+  fi
+}
+
+# Handle a Stop event
+#
+# Fired when Claude finishes responding.
+_handle_stop() {
+  local window
+  window="$(_tmux_pane_window_name)"
+  _notify "Claude [${window}]: done"
+}
+
+# Handle a Notification event
+#
+# Fired when Claude needs attention (permission prompts, idle prompts, etc.).
+_handle_notification() {
+  local window
+  window="$(_tmux_pane_window_name)"
+  _notify "Claude [${window}]: waiting"
+}
+
+# Main entry point
+#
+# Guards against non-tmux environments, reads the event args from stdin,
+# dispatches to the appropriate event handler, then runs auto-focus.
+main() {
+  if [[ -z "${TMUX:-}" ]] || [[ -z "${TMUX_PANE:-}" ]]; then
+    exit 0
+  fi
+
+  local event_args
+  event_args="$(cat)"
+
+  local event_name
+  event_name="$(_json_field "hook_event_name" "$event_args")"
+
+  case "$event_name" in
+  Stop)
+    _handle_stop
+    ;;
+  Notification)
+    _handle_notification
+    ;;
+  esac
+
+  _auto_focus
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `tmux-notify` plugin with three pane-specific notification mechanisms: bell, display-message, and auto-focus
- Hooks into `Stop` (Claude finishes) and `Notification` (Claude needs attention) events
- Display-message shows contextual text from the hook payload (e.g. permission prompt title/message, or truncated last assistant message)
- All mechanisms configurable via tmux session options (`@claude-notify-bell`, `@claude-notify-message`, `@claude-notify-auto-focus`)
- Automatically suppressed when Claude's pane is already active
- Display-message scoped to current tmux session only
- Updates repo README with new extension entry

## New files

| File | Purpose |
|------|---------|
| `plugins/tmux-notify/.claude-plugin/plugin.json` | Plugin manifest |
| `plugins/tmux-notify/hooks/hooks.json` | Hook definitions for Stop + Notification |
| `plugins/tmux-notify/scripts/tmux_notify.sh` | Notification script |
| `plugins/tmux-notify/README.md` | User-facing documentation |

## Modified files

| File | Change |
|------|--------|
| `.claude-plugin/marketplace.json` | Add tmux-notify entry |
| `README.md` | Add tmux-notify to available extensions table |

## Test plan

- [x] CI validation passes (`validate.yml`)
- [x] `jq empty` on all JSON files
- [x] `bash -n` on shell script
- [x] Install via `/plugin install tmux-notify@claude-extensions` in a tmux session
- [x] Bell fires when Claude finishes in a background pane
- [x] `tmux set-option -g @claude-notify-message on` → display-message appears when switching away from Claude's window
- [x] `tmux set-option -g @claude-notify-auto-focus on` → pane auto-selects on completion
- [x] No notifications when Claude's pane is already active
- [x] Two concurrent Claude instances notify independently

Closes #2