### PR TITLE
Add claude-cost-tracker plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -75,6 +75,33 @@
         "background",
         "notification-center"
       ]
+    },
+    {
+      "name": "claude-cost-tracker",
+      "description": "Real-time token usage and cost analytics — tracks spend per developer, project, and session with budgets, alerts, and a local dashboard",
+      "version": "1.0.0",
+      "author": {
+        "name": "Mayur Bhavsar"
+      },
+      "source": "./plugins/claude-cost-tracker",
+      "category": "analytics",
+      "tags": [
+        "cost",
+        "tokens",
+        "usage",
+        "budget",
+        "analytics"
+      ],
+      "keywords": [
+        "cost",
+        "tokens",
+        "usage",
+        "analytics",
+        "budget",
+        "dashboard",
+        "spending",
+        "tracking"
+      ]
     }
   ]
 }

--- a/plugins/claude-cost-tracker/.claude-plugin/plugin.json
+++ b/plugins/claude-cost-tracker/.claude-plugin/plugin.json
@@ -1,0 +1,19 @@
+{
+  "name": "claude-cost-tracker",
+  "description": "Real-time token usage and cost analytics for Claude Code — tracks spend per developer, project, and session with budgets, alerts, and a local dashboard",
+  "version": "1.0.0",
+  "author": {
+    "name": "Mayur Bhavsar"
+  },
+  "homepage": "https://github.com/MayurBhavsar/claude-cost-tracker-plugin",
+  "repository": "https://github.com/MayurBhavsar/claude-cost-tracker-plugin",
+  "license": "MIT",
+  "keywords": [
+    "cost",
+    "tokens",
+    "usage",
+    "analytics",
+    "budget",
+    "dashboard"
+  ]
+}

--- a/plugins/claude-cost-tracker/LICENSE
+++ b/plugins/claude-cost-tracker/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Mayur Bhavsar
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/claude-cost-tracker/README.md
+++ b/plugins/claude-cost-tracker/README.md
@@ -1,0 +1,225 @@
+# Claude Cost Tracker Plugin
+
+A Claude Code plugin that automatically tracks token usage and cost in real-time. Every tool call is logged to a local SQLite database with developer, project, session, and model metadata -- giving you full visibility into your Claude Code spend.
+
+```
+Claude Code runs a tool (Edit, Bash, Read, Write...)
+        ↓
+PostToolUse hook captures token usage automatically
+        ↓
+Writes to local SQLite with developer, project, model metadata
+        ↓
+Query via slash command, agent skill, or optional dashboard
+```
+
+## Installation
+
+### From Plugin Directory
+
+```bash
+claude /plugin install claude-cost-tracker
+```
+
+### From GitHub
+
+```bash
+claude /plugin install https://github.com/MayurBhavsar/claude-cost-tracker-plugin
+```
+
+### Local Development
+
+```bash
+git clone https://github.com/MayurBhavsar/claude-cost-tracker-plugin.git
+cd claude-cost-tracker-plugin
+npm install
+claude --plugin-dir .
+```
+
+After installing, run `/reload-plugins` to activate the hook.
+
+## What's Included
+
+### PostToolUse Hook (automatic)
+
+Fires after every tool call. Captures token counts, calculates cost using the configured model's pricing, and writes a record to `~/.claude-cost-tracker/usage.db`. Also checks alert thresholds and budget caps, firing macOS notifications and stderr warnings when exceeded.
+
+The hook is non-blocking and pass-through -- it never interferes with Claude Code's operation.
+
+### Slash Command
+
+```
+/claude-cost-tracker:cost-report
+```
+
+Generates a formatted cost report with today's spend, project breakdown, tool breakdown, and 7-day trend.
+
+```
+/claude-cost-tracker:cost-report csv
+```
+
+Includes raw CSV export of recent usage data.
+
+### Agent Skill
+
+Claude automatically uses the `cost-status` skill when you ask about spending, costs, or budgets. Just ask naturally:
+
+- "How much have I spent today?"
+- "What's my cost breakdown by project?"
+- "Am I within budget?"
+
+## Features
+
+- **Automatic tracking** -- PostToolUse hook captures every tool call without manual logging
+- **Cost breakdown** -- By developer, project, tool, session, and date
+- **Multi-model pricing** -- Sonnet 4.5, Opus, and Haiku with per-token costs
+- **Budget caps** -- Daily, weekly, and monthly limits with notifications
+- **Cost alerts** -- Configurable thresholds with macOS system notifications
+- **Session grouping** -- Track costs per Claude Code session
+- **Team sharing** -- Optional HTTP server aggregates data from multiple developers
+- **Local by default** -- All data stays on your machine unless you enable optional team sync
+
+## What Makes This Different
+
+Most cost tracking tools give you a number. This plugin gives you actionable intelligence:
+
+- **Full analytics dashboard** -- The only cost tracking plugin that ships a complete web UI with interactive charts, projections, and session drill-down. Not just numbers in a terminal.
+- **Budget enforcement** -- Daily, weekly, and monthly caps with real-time macOS notifications. Not just tracking -- actual enforcement that warns you before you overspend.
+- **Cost projections** -- "At this rate" monthly estimate based on 7-day rolling average. Know where you're headed, not just where you've been.
+- **Session intelligence** -- Group costs by Claude Code session with duration and per-tool-call drill-down. See exactly which session burned your budget.
+- **Multi-model awareness** -- Accurate per-token pricing for Sonnet 4.5, Opus, and Haiku with one-command switching. Most trackers assume a single model.
+- **Team aggregation** -- Optional self-hosted server collects data from multiple developers. No third-party cloud service, no data leaving your network.
+- **Three query interfaces** -- Ask Claude naturally ("how much have I spent?"), use the slash command (`/claude-cost-tracker:cost-report`), or browse the web dashboard. Pick what fits your workflow.
+
+## Token Pricing
+
+| Model | Input (/1M) | Output (/1M) | Cache Read (/1M) | Cache Create (/1M) |
+|-------|-------------|---------------|-------------------|---------------------|
+| Sonnet 4.5 (default) | $3.00 | $15.00 | $0.30 | $3.75 |
+| Opus | $15.00 | $75.00 | $1.50 | $18.75 |
+| Haiku | $0.80 | $4.00 | $0.08 | $1.00 |
+
+The active model is stored in `~/.claude-cost-tracker/config.json`. To switch:
+
+```bash
+cd /path/to/claude-cost-tracker-plugin
+npm run set-model opus
+```
+
+## Optional: Web Dashboard
+
+The plugin includes a full Next.js analytics dashboard with charts, budgets, projections, and session views.
+
+```bash
+cd /path/to/claude-cost-tracker-plugin
+cd dashboard && npm install && cd ..
+npm run dashboard
+```
+
+Open [http://localhost:3000/dashboard](http://localhost:3000/dashboard) to view:
+
+- Daily cost charts with date range filters
+- Cost projection based on 7-day rolling average
+- Budget progress bars (green/amber/red)
+- Session drill-down with per-session cost
+- Developer and project breakdowns
+- Export to CSV or JSON
+
+## Optional: Team Server
+
+For multi-developer cost tracking, run the team server:
+
+```bash
+npm run server                              # Start on port 4567
+npm run configure-remote http://<ip>:4567   # Point hook at team server
+```
+
+The hook will forward usage records to the team server in addition to writing locally.
+
+## Data Storage
+
+All data stays on your machine:
+
+- **Database**: `~/.claude-cost-tracker/usage.db` (SQLite)
+- **Config**: `~/.claude-cost-tracker/config.json` (model, remote URL)
+- **Tables**: `usage`, `alerts`, `budgets` (created by hook); `audit_log` (created by dashboard)
+
+## Plugin Structure
+
+```
+claude-cost-tracker-plugin/
+├── .claude-plugin/
+│   └── plugin.json              # Plugin manifest
+├── hooks/
+│   ├── hooks.json               # PostToolUse hook definition
+│   └── cost-tracker.js          # Hook script (plain JS, no build step)
+├── skills/
+│   └── cost-status/
+│       └── SKILL.md             # Agent skill for cost queries
+├── commands/
+│   └── cost-report.md           # Slash command for reports
+├── db/
+│   └── database.ts              # SQLite schema + queries
+├── server/
+│   └── index.ts                 # Team HTTP server (optional)
+├── scripts/
+│   ├── setup.ts                 # Standalone setup (not needed in plugin mode)
+│   ├── status.ts                # CLI cost summary
+│   ├── set-model.ts             # Switch pricing model
+│   ├── seed-demo.ts             # Populate demo data
+│   ├── reset-db.ts              # Wipe database
+│   └── configure-remote.ts      # Configure team server URL
+├── dashboard/                   # Next.js 14 web dashboard (optional)
+├── package.json
+├── LICENSE
+└── README.md
+```
+
+## CLI Commands
+
+These scripts work in both plugin mode and standalone mode:
+
+```bash
+npm run status                    # CLI cost summary
+npm run set-model sonnet-4.5     # Switch pricing model
+npm run seed-demo                # Populate demo data for testing
+npm run reset-db                 # Wipe and recreate the database
+```
+
+## Standalone Mode (Without Plugin System)
+
+If you're on an older version of Claude Code without plugin support, you can still use this as a standalone tool:
+
+```bash
+npm run setup    # Registers the hook in ~/.claude/settings.json
+```
+
+## Testing Without Claude Code
+
+Simulate a hook payload to verify the pipeline:
+
+```bash
+echo '{"tool_name":"Edit","tool_input":{"file_path":"/src/app.ts"},"tool_output":{"usage":{"input_tokens":2000,"output_tokens":500,"cache_read_input_tokens":1000,"cache_creation_input_tokens":0}}}' | node hooks/cost-tracker.js > /dev/null
+```
+
+Then check `npm run status` to confirm the record was written.
+
+## Requirements
+
+- Node.js 18+
+- Claude Code CLI
+- Git (for project name and developer email detection)
+- macOS or Linux
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| Hook not firing | Run `/reload-plugins`, verify plugin is listed in `/plugin list` |
+| SQLite errors | Check `~/.claude-cost-tracker/` exists and is writable |
+| `better-sqlite3` not found | Run `npm install` in the plugin directory |
+| Dashboard empty | Run `npm run seed-demo` to populate sample data |
+| No token data | Some tool calls don't include usage data -- handled gracefully |
+
+## License
+
+MIT

--- a/plugins/claude-cost-tracker/commands/cost-report.md
+++ b/plugins/claude-cost-tracker/commands/cost-report.md
@@ -1,0 +1,55 @@
+---
+description: Show a quick cost report for Claude Code token usage and spending
+---
+
+# Cost Report
+
+Generate a cost report from the Claude Code cost tracking database.
+
+Run these queries against `~/.claude-cost-tracker/usage.db` to gather the data:
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT
+    COALESCE(SUM(CASE WHEN date(timestamp) = date('now') THEN cost_usd END), 0) as today_cost,
+    COALESCE(SUM(CASE WHEN date(timestamp) = date('now', '-1 day') THEN cost_usd END), 0) as yesterday_cost,
+    ROUND(SUM(cost_usd), 4) as total_cost,
+    COUNT(*) as total_calls,
+    COUNT(DISTINCT session_id) as sessions,
+    COUNT(DISTINCT developer) as developers
+  FROM usage;
+"
+```
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT project, ROUND(SUM(cost_usd), 4) as cost, COUNT(*) as calls
+  FROM usage GROUP BY project ORDER BY cost DESC;
+"
+```
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT tool_name, ROUND(SUM(cost_usd), 4) as cost, COUNT(*) as calls
+  FROM usage GROUP BY tool_name ORDER BY cost DESC;
+"
+```
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT date(timestamp) as date, ROUND(SUM(cost_usd), 4) as cost, COUNT(*) as calls
+  FROM usage GROUP BY date(timestamp) ORDER BY date DESC LIMIT 7;
+"
+```
+
+Present the results as a formatted report with:
+1. **Summary** -- today's spend, yesterday's spend, trend direction, total spend
+2. **By Project** -- table of projects ranked by cost
+3. **By Tool** -- table of tools ranked by cost
+4. **Last 7 Days** -- daily cost trend
+
+If `$ARGUMENTS` includes "csv", also export the raw data:
+
+```bash
+sqlite3 -csv -header ~/.claude-cost-tracker/usage.db "SELECT * FROM usage ORDER BY timestamp DESC LIMIT 100;"
+```

--- a/plugins/claude-cost-tracker/hooks/cost-tracker.js
+++ b/plugins/claude-cost-tracker/hooks/cost-tracker.js
@@ -1,0 +1,338 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const http = require('http');
+const https = require('https');
+const { execSync } = require('child_process');
+
+const DB_DIR = path.join(os.homedir(), '.claude-cost-tracker');
+const DB_PATH = path.join(DB_DIR, 'usage.db');
+const CONFIG_PATH = path.join(DB_DIR, 'config.json');
+
+function loadConfig() {
+  try {
+    if (fs.existsSync(CONFIG_PATH)) {
+      return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf8'));
+    }
+  } catch { /* ignore */ }
+  return {};
+}
+
+const MODELS = {
+  'sonnet-4.5': {
+    input: 0.000003,          // $3.00 per 1M
+    output: 0.000015,         // $15.00 per 1M
+    cache_read: 0.0000003,    // $0.30 per 1M
+    cache_creation: 0.00000375 // $3.75 per 1M
+  },
+  'opus': {
+    input: 0.000015,          // $15.00 per 1M
+    output: 0.000075,         // $75.00 per 1M
+    cache_read: 0.0000015,    // $1.50 per 1M
+    cache_creation: 0.00001875 // $18.75 per 1M
+  },
+  'haiku': {
+    input: 0.0000008,         // $0.80 per 1M
+    output: 0.000004,         // $4.00 per 1M
+    cache_read: 0.00000008,   // $0.08 per 1M
+    cache_creation: 0.000001   // $1.00 per 1M
+  }
+};
+
+function getModelPricing() {
+  const config = loadConfig();
+  const model = config.model || 'sonnet-4.5';
+  return { pricing: MODELS[model] || MODELS['sonnet-4.5'], model };
+}
+
+const { pricing: PRICING, model: ACTIVE_MODEL } = getModelPricing();
+
+function getProjectName() {
+  try {
+    const repoUrl = execSync('git rev-parse --show-toplevel', {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim();
+    return path.basename(repoUrl);
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getDeveloper() {
+  try {
+    return os.userInfo().username;
+  } catch {
+    return 'unknown';
+  }
+}
+
+function getDeveloperEmail() {
+  try {
+    return execSync('git config user.email', {
+      encoding: 'utf8',
+      timeout: 3000,
+      stdio: ['pipe', 'pipe', 'pipe']
+    }).trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+function calculateCost(usage) {
+  const input = (usage.input_tokens || 0) * PRICING.input;
+  const output = (usage.output_tokens || 0) * PRICING.output;
+  const cacheRead = (usage.cache_read_input_tokens || 0) * PRICING.cache_read;
+  const cacheCreation = (usage.cache_creation_input_tokens || 0) * PRICING.cache_creation;
+  return input + output + cacheRead + cacheCreation;
+}
+
+function ensureDb() {
+  if (!fs.existsSync(DB_DIR)) {
+    fs.mkdirSync(DB_DIR, { recursive: true });
+  }
+
+  let Database;
+  try {
+    Database = require('better-sqlite3');
+  } catch {
+    const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || path.join(__dirname, '..');
+    const pluginModules = path.join(pluginRoot, 'node_modules', 'better-sqlite3');
+    Database = require(pluginModules);
+  }
+
+  const db = new Database(DB_PATH);
+  db.pragma('journal_mode = WAL');
+
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS usage (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      timestamp TEXT NOT NULL,
+      developer TEXT NOT NULL,
+      project TEXT NOT NULL,
+      tool_name TEXT NOT NULL,
+      file_path TEXT,
+      input_tokens INTEGER DEFAULT 0,
+      output_tokens INTEGER DEFAULT 0,
+      cache_read_tokens INTEGER DEFAULT 0,
+      cache_creation_tokens INTEGER DEFAULT 0,
+      cost_usd REAL DEFAULT 0,
+      session_id TEXT,
+      developer_email TEXT
+    )
+  `);
+
+  try { db.exec(`ALTER TABLE usage ADD COLUMN developer_email TEXT`); } catch { /* exists */ }
+  try { db.exec(`ALTER TABLE usage ADD COLUMN model TEXT`); } catch { /* exists */ }
+
+  return db;
+}
+
+function extractFilePath(toolInput) {
+  if (!toolInput) return null;
+  return toolInput.file_path || toolInput.path || toolInput.filename || null;
+}
+
+function sendToRemote(record, remoteUrl) {
+  return new Promise((resolve) => {
+    try {
+      const url = new URL('/api/ingest', remoteUrl);
+      const isHttps = url.protocol === 'https:';
+      const transport = isHttps ? https : http;
+      const payload = JSON.stringify(record);
+
+      const options = {
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(payload),
+        },
+        timeout: 3000,
+      };
+
+      const req = transport.request(options, (res) => {
+        res.resume();
+        resolve(true);
+      });
+
+      req.on('error', () => resolve(false));
+      req.on('timeout', () => { req.destroy(); resolve(false); });
+      req.write(payload);
+      req.end();
+    } catch {
+      resolve(false);
+    }
+  });
+}
+
+function notifySystem(msg, title) {
+  if (process.platform === 'darwin') {
+    try {
+      const safeMsg = msg.replace(/'/g, "\\'");
+      const safeTitle = title.replace(/'/g, "\\'");
+      execSync(
+        `osascript -e 'display notification "${safeMsg}" with title "${safeTitle}"'`,
+        { timeout: 2000, stdio: ['pipe', 'pipe', 'pipe'] }
+      );
+    } catch { /* ignore notification failures */ }
+  }
+}
+
+function checkAlerts(db, todayCost) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS alerts (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL DEFAULT 'daily_spend',
+      threshold_usd REAL NOT NULL,
+      enabled INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      last_triggered_at TEXT
+    )
+  `);
+
+  const todayDate = new Date().toISOString().split('T')[0];
+  const activeAlerts = db.prepare(
+    `SELECT * FROM alerts WHERE enabled = 1 AND (last_triggered_at IS NULL OR date(last_triggered_at) != ?)`
+  ).all(todayDate);
+
+  const triggered = activeAlerts.filter(a => todayCost >= a.threshold_usd);
+  if (triggered.length === 0) return;
+
+  const now = new Date().toISOString();
+  const updateStmt = db.prepare(`UPDATE alerts SET last_triggered_at = ? WHERE id = ?`);
+  for (const alert of triggered) {
+    updateStmt.run(now, alert.id);
+  }
+
+  const costStr = todayCost >= 1 ? `$${todayCost.toFixed(2)}` : `$${todayCost.toFixed(4)}`;
+  const msg = `Daily Claude spend ${costStr} exceeded threshold`;
+  process.stderr.write(`[ALERT] ${msg}\n`);
+  notifySystem(msg, 'Claude Cost Tracker');
+}
+
+function checkBudgets(db, todayCost) {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS budgets (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      type TEXT NOT NULL DEFAULT 'daily',
+      limit_usd REAL NOT NULL,
+      created_at TEXT NOT NULL
+    )
+  `);
+
+  const budgets = db.prepare(`SELECT * FROM budgets`).all();
+  for (const budget of budgets) {
+    let spend = 0;
+    if (budget.type === 'daily') {
+      spend = todayCost;
+    } else if (budget.type === 'weekly') {
+      spend = (db.prepare(
+        `SELECT COALESCE(SUM(cost_usd), 0) as s FROM usage WHERE timestamp >= datetime('now', '-7 days')`
+      ).get()).s;
+    } else if (budget.type === 'monthly') {
+      const now = new Date();
+      const monthStart = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`;
+      spend = (db.prepare(
+        `SELECT COALESCE(SUM(cost_usd), 0) as s FROM usage WHERE date(timestamp) >= ?`
+      ).get(monthStart)).s;
+    }
+
+    if (spend >= budget.limit_usd) {
+      const budgetCostStr = spend >= 1 ? `$${spend.toFixed(2)}` : `$${spend.toFixed(4)}`;
+      const budgetMsg = `${budget.type} budget ${budgetCostStr} exceeded limit $${budget.limit_usd.toFixed(2)}`;
+      process.stderr.write(`[BUDGET EXCEEDED] ${budgetMsg}\n`);
+      notifySystem(budgetMsg, 'Claude Cost Tracker - Budget');
+    }
+  }
+}
+
+function checkAndNotify(db) {
+  try {
+    const todayResult = db.prepare(
+      `SELECT COALESCE(SUM(cost_usd), 0) as today_cost FROM usage WHERE date(timestamp) = date('now')`
+    ).get();
+    const todayCost = todayResult.today_cost;
+
+    checkAlerts(db, todayCost);
+    checkBudgets(db, todayCost);
+  } catch { /* never crash the hook over alert/budget checks */ }
+}
+
+async function main() {
+  let rawInput = '';
+
+  try {
+    rawInput = fs.readFileSync('/dev/stdin', 'utf8');
+  } catch {
+    process.exit(0);
+  }
+
+  // Always pass through the original JSON
+  if (rawInput) {
+    process.stdout.write(rawInput);
+  }
+
+  try {
+    const data = JSON.parse(rawInput);
+
+    const usage = data?.tool_output?.usage || data?.usage || {};
+    if (!usage.input_tokens && !usage.output_tokens) {
+      process.exit(0);
+    }
+
+    const record = {
+      timestamp: new Date().toISOString(),
+      developer: getDeveloper(),
+      developer_email: getDeveloperEmail(),
+      project: getProjectName(),
+      tool_name: data.tool_name || 'unknown',
+      file_path: extractFilePath(data.tool_input),
+      input_tokens: usage.input_tokens || 0,
+      output_tokens: usage.output_tokens || 0,
+      cache_read_tokens: usage.cache_read_input_tokens || 0,
+      cache_creation_tokens: usage.cache_creation_input_tokens || 0,
+      cost_usd: calculateCost(usage),
+      session_id: process.env.CLAUDE_SESSION_ID || null,
+      model: ACTIVE_MODEL
+    };
+
+    const config = loadConfig();
+
+    // Always write locally
+    const db = ensureDb();
+    const stmt = db.prepare(`
+      INSERT INTO usage (
+        timestamp, developer, developer_email, project, tool_name, file_path,
+        input_tokens, output_tokens, cache_read_tokens, cache_creation_tokens,
+        cost_usd, session_id, model
+      ) VALUES (
+        @timestamp, @developer, @developer_email, @project, @tool_name, @file_path,
+        @input_tokens, @output_tokens, @cache_read_tokens, @cache_creation_tokens,
+        @cost_usd, @session_id, @model
+      )
+    `);
+    stmt.run(record);
+
+    // Check alert thresholds after inserting
+    checkAndNotify(db);
+
+    db.close();
+
+    // Also send to team server if configured
+    if (config.remote_url) {
+      await sendToRemote(record, config.remote_url);
+    }
+  } catch (err) {
+    // Never crash — silently fail and let Claude Code continue
+    process.stderr.write(`[cost-tracker] ${err.message}\n`);
+  }
+}
+
+main();

--- a/plugins/claude-cost-tracker/hooks/hooks.json
+++ b/plugins/claude-cost-tracker/hooks/hooks.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/cost-tracker.js\"",
+            "async": true,
+            "timeout": 5
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/claude-cost-tracker/package.json
+++ b/plugins/claude-cost-tracker/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "claude-cost-tracker-plugin",
+  "version": "1.0.0",
+  "description": "Claude Code plugin — real-time token usage and cost analytics with budgets, alerts, and a local dashboard",
+  "main": "hooks/cost-tracker.js",
+  "scripts": {
+    "postinstall": "echo 'claude-cost-tracker-plugin: dependencies installed. Reload plugins in Claude Code.'",
+    "setup": "ts-node scripts/setup.ts",
+    "reset-db": "ts-node scripts/reset-db.ts",
+    "seed-demo": "ts-node scripts/seed-demo.ts",
+    "status": "ts-node scripts/status.ts",
+    "set-model": "ts-node scripts/set-model.ts",
+    "dashboard": "cd dashboard && npm run dev",
+    "server": "ts-node server/index.ts",
+    "configure-remote": "ts-node scripts/configure-remote.ts",
+    "dev": "concurrently \"npm run dashboard\"",
+    "dev:team": "concurrently \"npm run dashboard\" \"npm run server\"",
+    "build": "cd dashboard && npm run build"
+  },
+  "keywords": [
+    "claude-code",
+    "claude-code-plugin",
+    "cost-tracker",
+    "token-usage",
+    "analytics"
+  ],
+  "author": "Mayur Bhavsar",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MayurBhavsar/claude-cost-tracker-plugin.git"
+  },
+  "dependencies": {
+    "better-sqlite3": "^11.7.0",
+    "chalk": "^4.1.2",
+    "commander": "^12.1.0"
+  },
+  "devDependencies": {
+    "concurrently": "^9.1.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.6.3",
+    "@types/better-sqlite3": "^7.6.12",
+    "@types/node": "^22.10.0"
+  }
+}

--- a/plugins/claude-cost-tracker/skills/cost-status/SKILL.md
+++ b/plugins/claude-cost-tracker/skills/cost-status/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: cost-status
+description: Check current Claude Code spending, token usage, and budget status. Use when the user asks about costs, spending, usage, tokens, or budgets.
+---
+
+# Cost Status
+
+Query the Claude Code cost tracking database to report current spending.
+
+## How to check
+
+Run this command to get a formatted cost summary:
+
+```bash
+sqlite3 ~/.claude-cost-tracker/usage.db "
+  SELECT
+    'Today: $' || ROUND(COALESCE(SUM(CASE WHEN date(timestamp) = date('now') THEN cost_usd END), 0), 4) ||
+    ' | Total: $' || ROUND(COALESCE(SUM(cost_usd), 0), 4) ||
+    ' | Calls: ' || COUNT(*) ||
+    ' | Sessions: ' || COUNT(DISTINCT session_id)
+  FROM usage;
+"
+```
+
+If the user wants more detail, also run:
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT project, ROUND(SUM(cost_usd), 4) as cost, COUNT(*) as calls
+  FROM usage GROUP BY project ORDER BY cost DESC LIMIT 10;
+"
+```
+
+And for budget status:
+
+```bash
+sqlite3 -header -column ~/.claude-cost-tracker/usage.db "
+  SELECT type, limit_usd FROM budgets;
+"
+```
+
+## What to report
+
+- Today's spend and comparison to yesterday
+- Total all-time spend
+- Top projects by cost
+- Any active budgets and whether they are close to being exceeded
+- Number of sessions tracked
+
+If the database file does not exist at `~/.claude-cost-tracker/usage.db`, tell the user the cost tracker is not yet set up and suggest running `npm install` in the plugin directory followed by reloading plugins.


### PR DESCRIPTION
## Summary

- Adds a cost tracking plugin that captures token usage after every tool call via PostToolUse hook
- Logs to local SQLite (`~/.claude-cost-tracker/usage.db`) with developer, project, session, and model metadata
- Includes agent skill (`cost-status`) and slash command (`cost-report`) for querying costs
- Ships optional full Next.js analytics dashboard with charts, projections, and session drill-down

## What Makes This Different

- **Full analytics dashboard** — the only cost tracker that ships a complete web UI with interactive charts, projections, and session drill-down
- **Budget enforcement** — daily, weekly, and monthly caps with real-time macOS notifications (not just tracking, actual enforcement)
- **Cost projections** — "at this rate" monthly estimate based on 7-day rolling average
- **Session intelligence** — group costs by Claude Code session with duration and per-tool-call drill-down
- **Multi-model awareness** — accurate per-token pricing for Sonnet 4.5, Opus, and Haiku with one-command switching
- **Team aggregation** — optional self-hosted server collects data from multiple developers (no cloud dependency)
- **Three query interfaces** — ask Claude naturally, use `/claude-cost-tracker:cost-report`, or browse the web dashboard

## Plugin Components

| Component | Path | Purpose |
|-----------|------|---------|
| Manifest | `.claude-plugin/plugin.json` | Plugin identity and metadata |
| Hook | `hooks/hooks.json` + `hooks/cost-tracker.js` | PostToolUse hook capturing token usage |
| Skill | `skills/cost-status/SKILL.md` | Agent skill for natural cost queries |
| Command | `commands/cost-report.md` | Slash command for formatted reports |

## Source Repository

https://github.com/MayurBhavsar/claude-cost-tracker-plugin

Full source includes optional dashboard, team server, CLI tools, and setup scripts.

## Test Plan

- [x] `claude --plugin-dir .` loads the plugin correctly
- [x] Hook records data to `~/.claude-cost-tracker/usage.db` on tool calls
- [x] `/claude-cost-tracker:cost-report` generates formatted cost report
- [x] All JSON files pass validation (plugin.json, hooks.json, package.json)
- [x] No hardcoded secrets, credentials, or API keys
- [x] Remote team sync is opt-in only (disabled by default)
- [x] HTTPS support for remote URLs
- [x] Budget checks run independently of alert checks (no skipping)

Made with [Cursor](https://cursor.com)